### PR TITLE
separating dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
     "url": "https://github.com/jksdua/bunyan-logzio/issues"
   },
   "homepage": "https://github.com/jksdua/bunyan-logzio",
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "bunyan": "^1.5.1",
-    "logzio-nodejs": "^0.3.6",
+    "logzio-nodejs": "^0.3.6"
+  },
+  "devDependencies": {
     "mocha": "^2.3.4",
     "should": "^8.0.0"
   }


### PR DESCRIPTION
`devDependencies` are supposed to be for dependencies you only need on development environments. They aren't installed when calling `npm install --production` like you should do on your production environment.
For more info see : http://stackoverflow.com/questions/18875674/whats-the-difference-between-dependencies-devdependencies-and-peerdependencies
